### PR TITLE
Add missing opcode constants

### DIFF
--- a/internal/evm/core/opcodes.go
+++ b/internal/evm/core/opcodes.go
@@ -4,44 +4,78 @@ import "fmt"
 
 const (
 	// 0x00 - 0x0f: Stop & Arithmetic
-	STOP   = 0x00
-	ADD    = 0x01
-	MUL    = 0x02
-	SUB    = 0x03
-	DIV    = 0x04
-	MOD    = 0x06
-	ADDMOD = 0x08
+	STOP       = 0x00
+	ADD        = 0x01
+	MUL        = 0x02
+	SUB        = 0x03
+	DIV        = 0x04
+	SDIV       = 0x05
+	MOD        = 0x06
+	SMOD       = 0x07
+	ADDMOD     = 0x08
+	MULMOD     = 0x09
+	EXP        = 0x0a
+	SIGNEXTEND = 0x0b
 
 	// 0x10 - 0x1f: Comparison & Bitwise
-	LT     = 0x10
-	GT     = 0x11
-	SLT    = 0x12
-	SGT    = 0x13
-	EQ     = 0x14
-	ISZERO = 0x15
-	AND    = 0x16
-	OR     = 0x17
-	NOT    = 0x19
-	SHL    = 0x1b
-	SHR    = 0x1c
+	LT        = 0x10
+	GT        = 0x11
+	SLT       = 0x12
+	SGT       = 0x13
+	EQ        = 0x14
+	ISZERO    = 0x15
+	AND       = 0x16
+	OR        = 0x17
+	XOR       = 0x18
+	NOT       = 0x19
+	BYTE      = 0x1a
+	SHL       = 0x1b
+	SHR       = 0x1c
+	SAR       = 0x1d
+	INVALID1E = 0x1e
 
 	// 0x20 - 0x2f: SHA3
-	SHA3     = 0x20
-	CODECOPY = 0x39
+	SHA3 = 0x20
 
 	// 0x30 - 0x4f: Environment
-	ADDRESS      = 0x30
-	CALLVALUE    = 0x34
-	CALLDATALOAD = 0x35
-	CALLDATASIZE = 0x36
+	ADDRESS        = 0x30
+	BALANCE        = 0x31
+	ORIGIN         = 0x32
+	CALLER         = 0x33
+	CALLVALUE      = 0x34
+	CALLDATALOAD   = 0x35
+	CALLDATASIZE   = 0x36
+	CALLDATACOPY   = 0x37
+	CODESIZE       = 0x38
+	CODECOPY       = 0x39
+	GASPRICE       = 0x3a
+	EXTCODESIZE    = 0x3b
+	EXTCODECOPY    = 0x3c
+	RETURNDATASIZE = 0x3d
+	RETURNDATACOPY = 0x3e
+	EXTCODEHASH    = 0x3f
+	BLOCKHASH      = 0x40
+	COINBASE       = 0x41
+	TIMESTAMP      = 0x42
+	NUMBER         = 0x43
+	DIFFICULTY     = 0x44
+	GASLIMIT       = 0x45
+	CHAINID        = 0x46
+	SELFBALANCE    = 0x47
+	BASEFEE        = 0x48
 
 	// 0x50 - 0x5f: Stack & Memory
 	POP      = 0x50
 	MLOAD    = 0x51
 	MSTORE   = 0x52
+	MSTORE8  = 0x53
+	SLOAD    = 0x54
+	SSTORE   = 0x55
 	JUMP     = 0x56
 	JUMPI    = 0x57
 	PC       = 0x58
+	MSIZE    = 0x59
+	GAS      = 0x5a
 	JUMPDEST = 0x5b
 	PUSH0    = 0x5f // EIP-3855
 
@@ -55,88 +89,95 @@ const (
 	SWAP1 = 0x90
 
 	// 0xf0+
-	RETURN  = 0xf3
-	REVERT  = 0xfd
-	INVALID = 0xfe
+	CREATE       = 0xf0
+	CALL         = 0xf1
+	CALLCODE     = 0xf2
+	RETURN       = 0xf3
+	DELEGATECALL = 0xf4
+	CREATE2      = 0xf5
+	STATICCALL   = 0xfa
+	REVERT       = 0xfd
+	INVALID      = 0xfe
+	SELFDESTRUCT = 0xff
 )
 
 var opcodeNames = map[byte]string{
-	STOP:         "STOP",
-	ADD:          "ADD",
-	MUL:          "MUL",
-	SUB:          "SUB",
-	DIV:          "DIV",
-	MOD:          "MOD",
-	ADDMOD:       "ADDMOD",
-	LT:           "LT",
-	GT:           "GT",
-	SLT:          "SLT",
-	SGT:          "SGT",
-	EQ:           "EQ",
-	ISZERO:       "ISZERO",
-	AND:          "AND",
-	OR:           "OR",
-	NOT:          "NOT",
-	SHL:          "SHL",
-	SHR:          "SHR",
-	SHA3:         "SHA3",
-	ADDRESS:      "ADDRESS",
-	CALLVALUE:    "CALLVALUE",
-	CALLDATALOAD: "CALLDATALOAD",
-	CALLDATASIZE: "CALLDATASIZE",
-	POP:          "POP",
-	MLOAD:        "MLOAD",
-	MSTORE:       "MSTORE",
-	JUMP:         "JUMP",
-	JUMPI:        "JUMPI",
-	PC:           "PC",
-	JUMPDEST:     "JUMPDEST",
-	PUSH0:        "PUSH0",
-	// additional opcodes without constants
-	0x05:    "SDIV",
-	0x07:    "SMOD",
-	0x09:    "MULMOD",
-	0x0a:    "EXP",
-	0x0b:    "SIGNEXTEND",
-	0x18:    "XOR",
-	0x1a:    "BYTE",
-	0x1d:    "SAR",
-	0x1e:    "INVALID",
-	0x31:    "BALANCE",
-	0x32:    "ORIGIN",
-	0x33:    "CALLER",
-	0x37:    "CALLDATACOPY",
-	0x38:    "CODESIZE",
-	0x3a:    "GASPRICE",
-	0x3b:    "EXTCODESIZE",
-	0x3c:    "EXTCODECOPY",
-	0x3d:    "RETURNDATASIZE",
-	0x3e:    "RETURNDATACOPY",
-	0x3f:    "EXTCODEHASH",
-	0x40:    "BLOCKHASH",
-	0x41:    "COINBASE",
-	0x42:    "TIMESTAMP",
-	0x43:    "NUMBER",
-	0x44:    "DIFFICULTY",
-	0x45:    "GASLIMIT",
-	0x46:    "CHAINID",
-	0x47:    "SELFBALANCE",
-	0x48:    "BASEFEE",
-	0x53:    "MSTORE8",
-	0x54:    "SLOAD",
-	0x55:    "SSTORE",
-	0x59:    "MSIZE",
-	0x5a:    "GAS",
-	0xf0:    "CREATE",
-	0xf1:    "CALL",
-	0xf2:    "CALLCODE",
-	0xf4:    "DELEGATECALL",
-	0xf5:    "CREATE2",
-	0xfa:    "STATICCALL",
-	0xff:    "SELFDESTRUCT",
-	RETURN:  "RETURN",
-	REVERT:  "REVERT",
-	INVALID: "INVALID",
+	STOP:           "STOP",
+	ADD:            "ADD",
+	MUL:            "MUL",
+	SUB:            "SUB",
+	DIV:            "DIV",
+	MOD:            "MOD",
+	ADDMOD:         "ADDMOD",
+	SDIV:           "SDIV",
+	SMOD:           "SMOD",
+	MULMOD:         "MULMOD",
+	EXP:            "EXP",
+	SIGNEXTEND:     "SIGNEXTEND",
+	LT:             "LT",
+	GT:             "GT",
+	SLT:            "SLT",
+	SGT:            "SGT",
+	EQ:             "EQ",
+	ISZERO:         "ISZERO",
+	AND:            "AND",
+	OR:             "OR",
+	XOR:            "XOR",
+	NOT:            "NOT",
+	BYTE:           "BYTE",
+	SHL:            "SHL",
+	SHR:            "SHR",
+	SAR:            "SAR",
+	INVALID1E:      "INVALID",
+	SHA3:           "SHA3",
+	ADDRESS:        "ADDRESS",
+	BALANCE:        "BALANCE",
+	ORIGIN:         "ORIGIN",
+	CALLER:         "CALLER",
+	CALLVALUE:      "CALLVALUE",
+	CALLDATALOAD:   "CALLDATALOAD",
+	CALLDATASIZE:   "CALLDATASIZE",
+	CALLDATACOPY:   "CALLDATACOPY",
+	CODESIZE:       "CODESIZE",
+	CODECOPY:       "CODECOPY",
+	GASPRICE:       "GASPRICE",
+	EXTCODESIZE:    "EXTCODESIZE",
+	EXTCODECOPY:    "EXTCODECOPY",
+	RETURNDATASIZE: "RETURNDATASIZE",
+	RETURNDATACOPY: "RETURNDATACOPY",
+	EXTCODEHASH:    "EXTCODEHASH",
+	BLOCKHASH:      "BLOCKHASH",
+	COINBASE:       "COINBASE",
+	TIMESTAMP:      "TIMESTAMP",
+	NUMBER:         "NUMBER",
+	DIFFICULTY:     "DIFFICULTY",
+	GASLIMIT:       "GASLIMIT",
+	CHAINID:        "CHAINID",
+	SELFBALANCE:    "SELFBALANCE",
+	BASEFEE:        "BASEFEE",
+	POP:            "POP",
+	MLOAD:          "MLOAD",
+	MSTORE:         "MSTORE",
+	MSTORE8:        "MSTORE8",
+	SLOAD:          "SLOAD",
+	SSTORE:         "SSTORE",
+	JUMP:           "JUMP",
+	JUMPI:          "JUMPI",
+	PC:             "PC",
+	MSIZE:          "MSIZE",
+	GAS:            "GAS",
+	JUMPDEST:       "JUMPDEST",
+	PUSH0:          "PUSH0",
+	CREATE:         "CREATE",
+	CALL:           "CALL",
+	CALLCODE:       "CALLCODE",
+	DELEGATECALL:   "DELEGATECALL",
+	CREATE2:        "CREATE2",
+	STATICCALL:     "STATICCALL",
+	SELFDESTRUCT:   "SELFDESTRUCT",
+	RETURN:         "RETURN",
+	REVERT:         "REVERT",
+	INVALID:        "INVALID",
 }
 
 // OpcodeName returns the mnemonic name of an opcode byte.


### PR DESCRIPTION
## Summary
- define constants for all referenced EVM opcodes
- use the constants within the opcode name map

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6842af7a2ee48320a0fdda88d6aad7c6