### PR TITLE
Enable runtime bytecode execution

### DIFF
--- a/cmd/echoevm/main.go
+++ b/cmd/echoevm/main.go
@@ -26,7 +26,7 @@ func main() {
 	interpreter := vm.New(code)
 	interpreter.Run()
 
-	// --- Step 5: Inspect stack state ---
+	// --- Step 5: Inspect stack state after constructor execution ---
 	switch interpreter.Stack().Len() {
 	case 1:
 		fmt.Printf("Final Result on Stack: %s\n", interpreter.Stack().Peek(0).String())
@@ -34,6 +34,25 @@ func main() {
 		fmt.Println("Execution finished. Stack is empty.")
 	default:
 		fmt.Printf("Execution finished. Stack height = %d\n", interpreter.Stack().Len())
+	}
+
+	// --- Step 6: If constructor returned runtime code, execute it ---
+	runtimeCode := interpreter.ReturnedCode()
+	if len(runtimeCode) > 0 {
+		fmt.Println("=== Runtime Bytecode ===")
+		utils.PrintBytecode(runtimeCode)
+
+		runtimeInterpreter := vm.New(runtimeCode)
+		runtimeInterpreter.Run()
+
+		switch runtimeInterpreter.Stack().Len() {
+		case 1:
+			fmt.Printf("Runtime Result on Stack: %s\n", runtimeInterpreter.Stack().Peek(0).String())
+		case 0:
+			fmt.Println("Runtime execution finished. Stack is empty.")
+		default:
+			fmt.Printf("Runtime execution finished. Stack height = %d\n", runtimeInterpreter.Stack().Len())
+		}
 	}
 }
 

--- a/internal/evm/vm/interpreter.go
+++ b/internal/evm/vm/interpreter.go
@@ -55,6 +55,7 @@ func init() {
 	// control
 	handlerMap[core.STOP] = opStop
 	handlerMap[core.RETURN] = opReturn
+	handlerMap[core.REVERT] = opRevert
 
 	// environment
 	handlerMap[core.CALLVALUE] = opCallValue
@@ -89,8 +90,8 @@ func (i *Interpreter) Run() {
 
 		handler(i, op)
 
-		// If RETURN or STOP, exit early
-		if op == core.RETURN || op == core.STOP {
+		// If RETURN, REVERT or STOP, exit early
+		if op == core.RETURN || op == core.REVERT || op == core.STOP {
 			return
 		}
 	}

--- a/internal/evm/vm/interpreter.go
+++ b/internal/evm/vm/interpreter.go
@@ -57,6 +57,7 @@ func init() {
 
 	// environment
 	handlerMap[core.CALLVALUE] = opCallValue
+	handlerMap[core.CALLDATASIZE] = opCallDataSize
 
 	// invalid opcode
 	handlerMap[core.INVALID] = opInvalid

--- a/internal/evm/vm/interpreter.go
+++ b/internal/evm/vm/interpreter.go
@@ -34,6 +34,7 @@ func init() {
 	handlerMap[core.MUL] = opMul
 	handlerMap[core.DIV] = opDiv
 	handlerMap[core.MOD] = opMod
+	handlerMap[core.LT] = opLt
 	handlerMap[core.EQ] = opEq
 	handlerMap[core.ISZERO] = opIsZero
 

--- a/internal/evm/vm/interpreter.go
+++ b/internal/evm/vm/interpreter.go
@@ -101,3 +101,10 @@ func (i *Interpreter) Stack() *core.Stack {
 func (i *Interpreter) Memory() *core.Memory {
 	return i.memory
 }
+
+// ReturnedCode returns the byte slice produced by a RETURN opcode.
+// It is primarily used to obtain the runtime bytecode generated during
+// contract creation.
+func (i *Interpreter) ReturnedCode() []byte {
+	return i.returned
+}

--- a/internal/evm/vm/op_arithmetic.go
+++ b/internal/evm/vm/op_arithmetic.go
@@ -53,3 +53,14 @@ func opIsZero(i *Interpreter, _ byte) {
 		i.stack.Push(big.NewInt(0))
 	}
 }
+
+// opLt compares the top two stack values and pushes 1 if the first
+// is strictly less than the second, otherwise pushes 0.
+func opLt(i *Interpreter, _ byte) {
+	x, y := i.stack.Pop(), i.stack.Pop()
+	if x.Cmp(y) < 0 {
+		i.stack.Push(big.NewInt(1))
+	} else {
+		i.stack.Push(big.NewInt(0))
+	}
+}

--- a/internal/evm/vm/op_control.go
+++ b/internal/evm/vm/op_control.go
@@ -16,3 +16,14 @@ func opReturn(i *Interpreter, _ byte) {
 	i.returned = ret
 	fmt.Printf("RETURN: 0x%x\n", ret)
 }
+
+// opRevert halts execution and marks the returned data as an error payload.
+// This simplified EVM does not differentiate between revert and return beyond
+// printing a message and storing the payload.
+func opRevert(i *Interpreter, _ byte) {
+	offset := i.stack.Pop().Uint64()
+	size := i.stack.Pop().Uint64()
+	ret := i.memory.Get(offset)[:size]
+	i.returned = ret
+	fmt.Printf("REVERT: 0x%x\n", ret)
+}

--- a/internal/evm/vm/op_env.go
+++ b/internal/evm/vm/op_env.go
@@ -6,3 +6,9 @@ import "math/big"
 func opCallValue(i *Interpreter, _ byte) {
 	i.stack.Push(big.NewInt(0)) // default to 0
 }
+
+// opCallDataSize pushes the size of the calldata onto the stack. Since this
+// toy EVM does not support transaction input, it always pushes 0.
+func opCallDataSize(i *Interpreter, _ byte) {
+	i.stack.Push(big.NewInt(0))
+}


### PR DESCRIPTION
## Summary
- expose interpreter's returned code
- run returned runtime code after constructor execution

## Testing
- `gofmt -w cmd/echoevm/main.go internal/evm/vm/interpreter.go`

------
https://chatgpt.com/codex/tasks/task_e_6842b36f68388320bcc413ede4de5007