### PR TITLE
Add CLI flags for bin file and execution mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,17 @@
 
 echoevm is a minimal Ethereum Virtual Machine (EVM) implementation in Go, focusing on bytecode execution from the ground up.
 
-More documentation and features will be added later.
+## Usage
+
+The `echoevm` command can execute the constructor contained in a Solidity
+`.bin` file. By default it runs the deployment bytecode and, if runtime code is
+returned, executes that code as well. Use the following flags to customise the
+behaviour:
+
+```
+./echoevm -bin path/to/contract.bin -mode [deploy|full]
+```
+
+- `-bin`  – path to the hex encoded bytecode file (defaults to `build/Add.bin`).
+- `-mode` – `deploy` to only run the constructor or `full` to also execute the
+  returned runtime code (default `full`).

--- a/cmd/echoevm/main.go
+++ b/cmd/echoevm/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"os"
 
@@ -10,8 +11,13 @@ import (
 )
 
 func main() {
+	// Command line flags
+	binPath := flag.String("bin", "build/Add.bin", "path to contract .bin file")
+	mode := flag.String("mode", "full", "execution mode: deploy or full")
+	flag.Parse()
+
 	// --- Step 1: Read hex-encoded constructor bytecode from file ---
-	data, err := os.ReadFile("build/Add.bin")
+	data, err := os.ReadFile(*binPath)
 	check(err, "failed to read bytecode file")
 
 	// --- Step 2: Decode hex string to bytecode []byte ---
@@ -36,9 +42,9 @@ func main() {
 		fmt.Printf("Execution finished. Stack height = %d\n", interpreter.Stack().Len())
 	}
 
-	// --- Step 6: If constructor returned runtime code, execute it ---
+	// --- Step 6: If constructor returned runtime code and mode is "full", execute it ---
 	runtimeCode := interpreter.ReturnedCode()
-	if len(runtimeCode) > 0 {
+	if *mode == "full" && len(runtimeCode) > 0 {
 		fmt.Println("=== Runtime Bytecode ===")
 		utils.PrintBytecode(runtimeCode)
 


### PR DESCRIPTION
## Summary
- add `bin` and `mode` flags to choose bytecode file and execution mode
- document command usage in README

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68462554dc5c8320a0e187e1a7490e0c