### PR TITLE
Add CLI calldata encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ behaviour:
 - `-function`/`-args` – alternatively specify a function signature and comma
   separated arguments (e.g. `-function "add(uint256,uint256)" -args "1,2"`)
   which will be ABI encoded automatically.
+
+### Examples
+
+Run with pre-encoded calldata:
+
+```bash
+go run ./cmd/echoevm/main.go -mode full -calldata 771602f7...
+```
+
+Encode arguments automatically for a function call:
+
+```bash
+go run ./cmd/echoevm/main.go -mode full -function 'add(uint256,uint256)' -args "1,2"
+```

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ returned, executes that code as well. Use the following flags to customise the
 behaviour:
 
 ```
-./echoevm -bin path/to/contract.bin -mode [deploy|full] \ 
-          [-calldata HEX | -function "sig" -args "1,2"]
+go run ./cmd/echoevm -bin path/to/contract.bin -mode [deploy|full] \
+        [-calldata HEX | -function "sig" -args "1,2"]
 ```
+
+*Note:* use the directory path (`./cmd/echoevm`) with `go run` so that all
+source files are compiled. Running `go run ./cmd/echoevm/main.go` will omit the
+flag parsing code located in `flags.go`.
 
 - `-bin`  – path to the hex encoded bytecode file (defaults to `build/Add.bin`).
 - `-mode` – `deploy` to only run the constructor or `full` to also execute the

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ returned, executes that code as well. Use the following flags to customise the
 behaviour:
 
 ```
-./echoevm -bin path/to/contract.bin -mode [deploy|full]
+./echoevm -bin path/to/contract.bin -mode [deploy|full] \ 
+          [-calldata HEX | -function "sig" -args "1,2"]
 ```
 
 - `-bin`  – path to the hex encoded bytecode file (defaults to `build/Add.bin`).
 - `-mode` – `deploy` to only run the constructor or `full` to also execute the
   returned runtime code (default `full`).
+- `-calldata` – hex-encoded calldata to supply when running the runtime code.
+- `-function`/`-args` – alternatively specify a function signature and comma
+  separated arguments (e.g. `-function "add(uint256,uint256)" -args "1,2"`)
+  which will be ABI encoded automatically.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ behaviour:
 Run with pre-encoded calldata:
 
 ```bash
-go run ./cmd/echoevm/main.go -mode full -calldata 771602f7...
+go run ./cmd/echoevm -mode full -calldata 771602f7...
 ```
 
 Encode arguments automatically for a function call:
 
 ```bash
-go run ./cmd/echoevm/main.go -mode full -function 'add(uint256,uint256)' -args "1,2"
+go run ./cmd/echoevm -mode full -function 'add(uint256,uint256)' -args "1,2"
 ```

--- a/cmd/echoevm/flags.go
+++ b/cmd/echoevm/flags.go
@@ -1,0 +1,24 @@
+package main
+
+import "flag"
+
+// cliConfig holds command line parameters for echoevm.
+type cliConfig struct {
+	Bin      string
+	Mode     string
+	Function string
+	Args     string
+	Calldata string
+}
+
+// parseFlags parses command line flags into a cliConfig.
+func parseFlags() *cliConfig {
+	cfg := &cliConfig{}
+	flag.StringVar(&cfg.Bin, "bin", "build/Add.bin", "path to contract .bin file")
+	flag.StringVar(&cfg.Mode, "mode", "full", "execution mode: deploy or full")
+	flag.StringVar(&cfg.Function, "function", "", "function signature, e.g. 'add(uint256,uint256)'")
+	flag.StringVar(&cfg.Args, "args", "", "comma separated arguments for the function")
+	flag.StringVar(&cfg.Calldata, "calldata", "", "hex encoded calldata")
+	flag.Parse()
+	return cfg
+}

--- a/cmd/echoevm/main.go
+++ b/cmd/echoevm/main.go
@@ -4,8 +4,12 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"math/big"
 	"os"
+	"strings"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/smallyunet/echoevm/internal/evm/vm"
 	"github.com/smallyunet/echoevm/utils"
 )
@@ -14,6 +18,9 @@ func main() {
 	// Command line flags
 	binPath := flag.String("bin", "build/Add.bin", "path to contract .bin file")
 	mode := flag.String("mode", "full", "execution mode: deploy or full")
+	functionSig := flag.String("function", "", "function signature, e.g. 'add(uint256,uint256)'")
+	argsStr := flag.String("args", "", "comma separated arguments for the function")
+	calldataHex := flag.String("calldata", "", "hex encoded calldata")
 	flag.Parse()
 
 	// --- Step 1: Read hex-encoded constructor bytecode from file ---
@@ -48,12 +55,18 @@ func main() {
 		fmt.Println("=== Runtime Bytecode ===")
 		utils.PrintBytecode(runtimeCode)
 
-		// Example calldata for Add.add(uint256,uint256) with arguments
-		// 1 and 2. This is the ABI-encoded function selector and
-		// parameters.
-		callData, _ := hex.DecodeString(
-			"771602f700000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
-		)
+		var callData []byte
+		var err error
+		switch {
+		case *calldataHex != "":
+			callData, err = hex.DecodeString(strings.TrimPrefix(*calldataHex, "0x"))
+		case *functionSig != "" && *argsStr != "":
+			callData, err = buildCallData(*functionSig, *argsStr)
+		default:
+			callData, _ = hex.DecodeString("771602f7000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002")
+		}
+		check(err, "failed to process calldata")
+
 		runtimeInterpreter := vm.NewWithCallData(runtimeCode, callData)
 		runtimeInterpreter.Run()
 
@@ -72,5 +85,80 @@ func main() {
 func check(err error, msg string) {
 	if err != nil {
 		panic(fmt.Sprintf("%s: %v", msg, err))
+	}
+}
+
+// buildCallData creates ABI encoded calldata from a function signature and
+// comma-separated arguments. Only a few basic types (uint256,int256,bool,string)
+// are supported. Numeric values can be provided in decimal or 0x-prefixed hex.
+func buildCallData(sig, argString string) ([]byte, error) {
+	open := strings.Index(sig, "(")
+	close := strings.LastIndex(sig, ")")
+	if open == -1 || close == -1 || close < open {
+		return nil, fmt.Errorf("invalid function signature")
+	}
+	typesPart := sig[open+1 : close]
+	typeNames := []string{}
+	if len(typesPart) > 0 {
+		for _, t := range strings.Split(typesPart, ",") {
+			typeNames = append(typeNames, strings.TrimSpace(t))
+		}
+	}
+
+	args := []string{}
+	if len(argString) > 0 {
+		for _, a := range strings.Split(argString, ",") {
+			args = append(args, strings.TrimSpace(a))
+		}
+	}
+
+	if len(typeNames) != len(args) {
+		return nil, fmt.Errorf("argument count mismatch")
+	}
+
+	var abiArgs abi.Arguments
+	values := make([]interface{}, len(args))
+	for i, tname := range typeNames {
+		t, err := abi.NewType(tname, "", nil)
+		if err != nil {
+			return nil, err
+		}
+		abiArgs = append(abiArgs, abi.Argument{Type: t})
+		val, err := parseArg(args[i], t)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = val
+	}
+	encoded, err := abiArgs.Pack(values...)
+	if err != nil {
+		return nil, err
+	}
+	selector := crypto.Keccak256([]byte(sig))[:4]
+	return append(selector, encoded...), nil
+}
+
+// parseArg converts a single argument string to the Go value required for ABI
+// encoding based on the provided type.
+func parseArg(val string, typ abi.Type) (interface{}, error) {
+	switch typ.T {
+	case abi.UintTy, abi.IntTy:
+		n := new(big.Int)
+		var ok bool
+		if strings.HasPrefix(val, "0x") {
+			n, ok = n.SetString(val[2:], 16)
+		} else {
+			n, ok = n.SetString(val, 10)
+		}
+		if !ok {
+			return nil, fmt.Errorf("invalid integer value: %s", val)
+		}
+		return n, nil
+	case abi.BoolTy:
+		return strings.ToLower(val) == "true", nil
+	case abi.StringTy:
+		return val, nil
+	default:
+		return nil, fmt.Errorf("unsupported type: %s", typ.String())
 	}
 }


### PR DESCRIPTION
## Summary
- add flags to provide function signature, arguments or raw calldata
- encode human-readable arguments into calldata
- update README with new flag usage

## Testing
- `go mod tidy` *(fails: Forbidden)*
- `go vet ./...` *(fails: no module for go-ethereum packages)*
- `go build ./...` *(fails: no module for go-ethereum packages)*

------
https://chatgpt.com/codex/tasks/task_e_6846a386df3883209dc7a3e71db82ffc