### PR TITLE
Add GitHub link to docs homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,13 @@
       initializing<span class="text-blue-400 animate-blink ml-1">_</span>
     </h1>
 
+    <!-- GitHub link -->
+    <a
+      href="https://github.com/smallyunet/echoevm"
+      class="mt-4 text-blue-400 hover:underline"
+      >View on GitHub</a
+    >
+
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- add a link to the project's GitHub repo on the docs homepage

## Testing
- `go test ./...` *(fails: no required module provides package github.com/ethereum/go-ethereum/accounts/abi)*
- `go vet ./...` *(fails: no required module provides package github.com/ethereum/go-ethereum/accounts/abi)*

------
https://chatgpt.com/codex/tasks/task_e_6846ddb7e688832099d7f35cfa1f9503