### PR TITLE
Adjust logging for runtime bytecode

### DIFF
--- a/cmd/echoevm/main.go
+++ b/cmd/echoevm/main.go
@@ -37,8 +37,9 @@ func main() {
 	check(err, "failed to decode hex bytecode")
 
 	// --- Step 3: Optional debug output ---
+	logger.Info().Msgf("Executing contract file: %s", cfg.Bin)
 	logger.Info().Msg("=== Disassembled Bytecode ===")
-	utils.PrintBytecode(logger, code)
+	utils.PrintBytecode(logger, code, zerolog.InfoLevel)
 
 	// --- Step 4: Create and run the interpreter with constructor bytecode ---
 	interpreter := vm.New(code)
@@ -57,8 +58,8 @@ func main() {
 	// --- Step 6: If constructor returned runtime code and mode is "full", execute it ---
 	runtimeCode := interpreter.ReturnedCode()
 	if cfg.Mode == "full" && len(runtimeCode) > 0 {
-		logger.Info().Msg("=== Runtime Bytecode ===")
-		utils.PrintBytecode(logger, runtimeCode)
+		logger.Debug().Msg("=== Runtime Bytecode ===")
+		utils.PrintBytecode(logger, runtimeCode, zerolog.DebugLevel)
 
 		var callData []byte
 		var err error
@@ -77,11 +78,11 @@ func main() {
 
 		switch runtimeInterpreter.Stack().Len() {
 		case 1:
-			logger.Info().Msgf("Runtime Result on Stack: %s", runtimeInterpreter.Stack().Peek(0).String())
+			logger.Info().Msgf("Contract %s result: %s", cfg.Bin, runtimeInterpreter.Stack().Peek(0).String())
 		case 0:
-			logger.Info().Msg("Runtime execution finished. Stack is empty.")
+			logger.Info().Msgf("Contract %s finished. Stack empty.", cfg.Bin)
 		default:
-			logger.Info().Msgf("Runtime execution finished. Stack height = %d", runtimeInterpreter.Stack().Len())
+			logger.Info().Msgf("Contract %s finished. Stack height = %d", cfg.Bin, runtimeInterpreter.Stack().Len())
 		}
 	}
 }

--- a/cmd/echoevm/main.go
+++ b/cmd/echoevm/main.go
@@ -38,8 +38,8 @@ func main() {
 
 	// --- Step 3: Optional debug output ---
 	logger.Info().Msgf("Executing contract file: %s", cfg.Bin)
-	logger.Info().Msg("=== Disassembled Bytecode ===")
-	utils.PrintBytecode(logger, code, zerolog.InfoLevel)
+	logger.Debug().Msg("=== Disassembled Bytecode ===")
+	utils.PrintBytecode(logger, code, zerolog.DebugLevel)
 
 	// --- Step 4: Create and run the interpreter with constructor bytecode ---
 	interpreter := vm.New(code)

--- a/utils/print.go
+++ b/utils/print.go
@@ -11,8 +11,9 @@ import (
 // For each opcode, it shows the program counter (PC), opcode hex value,
 // and the mnemonic name (e.g., ADD, PUSH1), with push data if applicable.
 // PrintBytecode logs EVM bytecode in a human-readable format using the provided logger.
-func PrintBytecode(log zerolog.Logger, code []byte) {
-	log.Info().Msg("=== Bytecode ===")
+func PrintBytecode(log zerolog.Logger, code []byte, level zerolog.Level) {
+	e := log.WithLevel(level)
+	e.Msg("=== Bytecode ===")
 
 	// pc represents the current position in the bytecode (like the program counter in EVM)
 	for pc := 0; pc < len(code); {
@@ -42,7 +43,7 @@ func PrintBytecode(log zerolog.Logger, code []byte) {
 			// Move to next byte (each non-PUSH opcode is 1 byte)
 			pc += 1
 		}
-		log.Info().Msg(line)
+		e.Msg(line)
 	}
 }
 

--- a/utils/print.go
+++ b/utils/print.go
@@ -12,8 +12,8 @@ import (
 // and the mnemonic name (e.g., ADD, PUSH1), with push data if applicable.
 // PrintBytecode logs EVM bytecode in a human-readable format using the provided logger.
 func PrintBytecode(log zerolog.Logger, code []byte, level zerolog.Level) {
-	e := log.WithLevel(level)
-	e.Msg("=== Bytecode ===")
+	// Emit a header at the provided log level
+	log.WithLevel(level).Msg("=== Bytecode ===")
 
 	// pc represents the current position in the bytecode (like the program counter in EVM)
 	for pc := 0; pc < len(code); {
@@ -43,7 +43,7 @@ func PrintBytecode(log zerolog.Logger, code []byte, level zerolog.Level) {
 			// Move to next byte (each non-PUSH opcode is 1 byte)
 			pc += 1
 		}
-		e.Msg(line)
+		log.WithLevel(level).Msg(line)
 	}
 }
 


### PR DESCRIPTION
## Summary
- output contract filename before execution
- print runtime bytecode at debug level
- expose log level for `PrintBytecode`
- summarize runtime result with contract name

## Testing
- `bash test/run_tests.sh` *(fails: unable to download Go modules)*

------
https://chatgpt.com/codex/tasks/task_e_684831e413888320ab746242a3e8ee48