### PR TITLE
Improve CLI parameter validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ go run ./cmd/echoevm -bin path/to/contract.bin -mode [deploy|full] \
 source files are compiled. Running `go run ./cmd/echoevm/main.go` will omit the
 flag parsing code located in `flags.go`.
 
-- `-bin`  – path to the hex encoded bytecode file (defaults to `build/Add.bin`).
+- `-bin`  – path to the hex encoded bytecode file (**required**).
 - `-mode` – `deploy` to only run the constructor or `full` to also execute the
   returned runtime code (default `full`).
 - `-calldata` – hex-encoded calldata to supply when running the runtime code.
 - `-function`/`-args` – alternatively specify a function signature and comma
   separated arguments (e.g. `-function "add(uint256,uint256)" -args "1,2"`)
-  which will be ABI encoded automatically.
+  which will be ABI encoded automatically. One of `-calldata` or `-function`/`-args` is required when running in `full` mode.
 
 ### Examples
 

--- a/cmd/echoevm/flags.go
+++ b/cmd/echoevm/flags.go
@@ -14,13 +14,17 @@ type cliConfig struct {
 
 // parseFlags parses command line flags into a cliConfig.
 func parseFlags() *cliConfig {
-	cfg := &cliConfig{}
-	flag.StringVar(&cfg.Bin, "bin", "build/Add.bin", "path to contract .bin file")
+        cfg := &cliConfig{}
+        flag.StringVar(&cfg.Bin, "bin", "", "path to contract .bin file (required)")
 	flag.StringVar(&cfg.Mode, "mode", "full", "execution mode: deploy or full")
 	flag.StringVar(&cfg.Function, "function", "", "function signature, e.g. 'add(uint256,uint256)'")
 	flag.StringVar(&cfg.Args, "args", "", "comma separated arguments for the function")
 	flag.StringVar(&cfg.Calldata, "calldata", "", "hex encoded calldata")
 	flag.StringVar(&cfg.LogLevel, "log-level", "info", "log level: trace, debug, info, warn, error")
-	flag.Parse()
-	return cfg
+        flag.Parse()
+        if cfg.Bin == "" {
+                flag.Usage()
+                panic("-bin flag is required")
+        }
+        return cfg
 }

--- a/cmd/echoevm/main.go
+++ b/cmd/echoevm/main.go
@@ -68,8 +68,8 @@ func main() {
 			callData, err = hex.DecodeString(strings.TrimPrefix(cfg.Calldata, "0x"))
 		case cfg.Function != "" && cfg.Args != "":
 			callData, err = buildCallData(cfg.Function, cfg.Args)
-		default:
-			callData, _ = hex.DecodeString("771602f7000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002")
+                default:
+                        logger.Fatal().Msg("provide -calldata or -function and -args")
 		}
 		check(err, "failed to process calldata")
 


### PR DESCRIPTION
## Summary
- make `-bin` mandatory instead of defaulting to `build/Add.bin`
- require calldata or function/args for runtime execution
- document required flags

## Testing
- `make test` *(fails: unable to download go-ethereum module)*

------
https://chatgpt.com/codex/tasks/task_e_684adfd37b088320bbc8b9afdcb692a0