### PR TITLE
Add interpreter step and REPL

### DIFF
--- a/cmd/repl/main.go
+++ b/cmd/repl/main.go
@@ -1,0 +1,63 @@
+//go:build evmrepl
+
+package main
+
+import (
+	"bufio"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+	zerologlog "github.com/rs/zerolog/log"
+	"github.com/smallyunet/echoevm/internal/evm/core"
+	"github.com/smallyunet/echoevm/internal/evm/vm"
+	"github.com/smallyunet/echoevm/utils"
+)
+
+func main() {
+	bin := flag.String("bin", "", "path to contract .bin file (required)")
+	flag.Parse()
+	if *bin == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	data, err := os.ReadFile(*bin)
+	if err != nil {
+		panic(err)
+	}
+	code, err := hex.DecodeString(string(data))
+	if err != nil {
+		panic(err)
+	}
+
+	cw := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.Kitchen}
+	logger := zerolog.New(cw).With().Timestamp().Logger()
+	zerologlog.Logger = logger
+	vm.SetLogger(logger)
+
+	utils.PrintBytecode(logger, code, zerolog.InfoLevel)
+
+	interp := vm.New(code)
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Println("Type ENTER to execute next opcode, 'quit' to exit")
+	for {
+		fmt.Print("repl> ")
+		line, _ := reader.ReadString('\n')
+		if strings.TrimSpace(line) == "quit" {
+			break
+		}
+		op, cont := interp.Step()
+		fmt.Printf("pc: 0x%04x op: %s\n", interp.PC(), core.OpcodeName(op))
+		fmt.Printf("stack: %v\n", interp.Stack().Snapshot())
+		fmt.Printf("memory: %s\n", interp.Memory().Snapshot())
+		if !cont {
+			fmt.Println("execution finished")
+			break
+		}
+	}
+}

--- a/cmd/repl/main.go
+++ b/cmd/repl/main.go
@@ -3,17 +3,13 @@
 package main
 
 import (
-	"bufio"
 	"encoding/hex"
 	"flag"
-	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
 	zerologlog "github.com/rs/zerolog/log"
-	"github.com/smallyunet/echoevm/internal/evm/core"
 	"github.com/smallyunet/echoevm/internal/evm/vm"
 	"github.com/smallyunet/echoevm/utils"
 )
@@ -42,22 +38,6 @@ func main() {
 
 	utils.PrintBytecode(logger, code, zerolog.InfoLevel)
 
-	interp := vm.New(code)
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Println("Type ENTER to execute next opcode, 'quit' to exit")
-	for {
-		fmt.Print("repl> ")
-		line, _ := reader.ReadString('\n')
-		if strings.TrimSpace(line) == "quit" {
-			break
-		}
-		op, cont := interp.Step()
-		fmt.Printf("pc: 0x%04x op: %s\n", interp.PC(), core.OpcodeName(op))
-		fmt.Printf("stack: %v\n", interp.Stack().Snapshot())
-		fmt.Printf("memory: %s\n", interp.Memory().Snapshot())
-		if !cont {
-			fmt.Println("execution finished")
-			break
-		}
-	}
+	r := NewREPL(code, os.Stdout, os.Stdin)
+	r.Run()
 }

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -1,0 +1,59 @@
+//go:build evmrepl
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/smallyunet/echoevm/internal/evm/core"
+	"github.com/smallyunet/echoevm/internal/evm/vm"
+)
+
+// REPL drives an interpreter interactively.
+type REPL struct {
+	interp *vm.Interpreter
+	in     *bufio.Reader
+	out    io.Writer
+}
+
+// NewREPL creates a REPL around the given bytecode.
+func NewREPL(code []byte, out io.Writer, in io.Reader) *REPL {
+	r := &REPL{
+		interp: vm.New(code),
+		out:    out,
+		in:     bufio.NewReader(in),
+	}
+	return r
+}
+
+// Run starts the interactive loop.
+func (r *REPL) Run() {
+	fmt.Fprintln(r.out, "Commands: <enter>|step, stack, mem, quit")
+	for {
+		fmt.Fprint(r.out, "repl> ")
+		line, _ := r.in.ReadString('\n')
+		switch strings.TrimSpace(line) {
+		case "", "step", "n":
+			op, cont := r.interp.Step()
+			fmt.Fprintf(r.out, "pc: 0x%04x op: %s\n", r.interp.PC(), core.OpcodeName(op))
+			fmt.Fprintf(r.out, "stack: %v\n", r.interp.Stack().Snapshot())
+			fmt.Fprintf(r.out, "memory: %s\n", r.interp.Memory().Snapshot())
+			if !cont {
+				fmt.Fprintln(r.out, "execution finished")
+				return
+			}
+		case "stack":
+			fmt.Fprintf(r.out, "stack: %v\n", r.interp.Stack().Snapshot())
+		case "mem", "memory":
+			fmt.Fprintf(r.out, "memory: %s\n", r.interp.Memory().Snapshot())
+		case "quit", "exit":
+			return
+		default:
+			fmt.Fprintln(r.out, "unknown command")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
        github.com/mattn/go-isatty v0.0.20 // indirect
        github.com/mmcloughlin/addchain v0.4.0 // indirect
        github.com/rs/zerolog v1.34.0
+       github.com/rs/zerolog/log v0.0.0
        github.com/supranational/blst v0.3.14 // indirect
        golang.org/x/crypto v0.35.0 // indirect
        golang.org/x/sync v0.11.0 // indirect
@@ -25,3 +26,4 @@ require (
 )
 
 replace github.com/rs/zerolog => ./stubs/zerolog
+replace github.com/rs/zerolog/log => ./stubs/zerolog/log

--- a/internal/evm/core/memory.go
+++ b/internal/evm/core/memory.go
@@ -1,6 +1,9 @@
 package core
 
-import "math/big"
+import (
+	"fmt"
+	"math/big"
+)
 
 type Memory struct {
 	data []byte
@@ -50,6 +53,11 @@ func (m *Memory) Read(offset, size uint64) []byte {
 		copy(out, m.data[offset:min(end, uint64(len(m.data)))])
 	}
 	return out
+}
+
+// Snapshot returns the current memory contents as a hex string.
+func (m *Memory) Snapshot() string {
+	return fmt.Sprintf("0x%x", m.data)
 }
 
 func min(a, b uint64) uint64 {

--- a/stubs/zerolog/log/go.mod
+++ b/stubs/zerolog/log/go.mod
@@ -1,0 +1,7 @@
+module github.com/rs/zerolog/log
+
+go 1.23
+
+require github.com/rs/zerolog v1.34.0
+
+replace github.com/rs/zerolog => ..

--- a/stubs/zerolog/log/log.go
+++ b/stubs/zerolog/log/log.go
@@ -1,0 +1,11 @@
+package log
+
+import "github.com/rs/zerolog"
+
+// Logger is a package level logger used for convenience.
+var Logger zerolog.Logger = zerolog.Nop()
+
+// SetLogger allows overriding the package level logger.
+func SetLogger(l zerolog.Logger) {
+	Logger = l
+}

--- a/stubs/zerolog/zerolog.go
+++ b/stubs/zerolog/zerolog.go
@@ -86,3 +86,12 @@ type ConsoleWriter struct {
 	Out        interface{}
 	TimeFormat string
 }
+
+// Write implements io.Writer so ConsoleWriter can be used with New(). It
+// simply forwards bytes to the configured Out writer.
+func (cw ConsoleWriter) Write(p []byte) (int, error) {
+	if w, ok := cw.Out.(interface{ Write([]byte) (int, error) }); ok {
+		return w.Write(p)
+	}
+	return len(p), nil
+}

--- a/stubs/zerolog/zerolog.go
+++ b/stubs/zerolog/zerolog.go
@@ -1,6 +1,9 @@
 package zerolog
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Minimal stub of zerolog for offline builds.
 
@@ -55,7 +58,29 @@ func (l Logger) Debug() *Event                { return &Event{out: l.out} }
 func (l Logger) Info() *Event                 { return &Event{out: l.out} }
 func (l Logger) Warn() *Event                 { return &Event{out: l.out} }
 func (l Logger) Error() *Event                { return &Event{out: l.out} }
+func (l Logger) Fatal() *Event                { return &Event{out: l.out} }
 func SetGlobalLevel(level Level)              {}
+
+func ParseLevel(s string) (Level, error) {
+	switch strings.ToLower(s) {
+	case "trace":
+		return TraceLevel, nil
+	case "debug":
+		return DebugLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "warn", "warning":
+		return WarnLevel, nil
+	case "error":
+		return ErrorLevel, nil
+	case "fatal":
+		return FatalLevel, nil
+	case "panic":
+		return PanicLevel, nil
+	default:
+		return InfoLevel, fmt.Errorf("invalid level: %s", s)
+	}
+}
 
 type ConsoleWriter struct {
 	Out        interface{}

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -21,7 +21,7 @@ run_contract() {
     local bin=$1
     shift
     echo "Executing $bin $*"
-    go run ./cmd/echoevm -bin "$bin" "$@"
+    go run -tags evmcli ./cmd/echoevm -bin "$bin" "$@"
     echo
 }
 


### PR DESCRIPTION
## Summary
- expose interpreter `Step` method and current PC
- track memory state with `Memory.Snapshot`
- use `Step` in `Run`
- add simple interactive REPL under `cmd/repl`

## Testing
- `go test ./...`
- `./test/run_tests.sh` *(fails: function main is undeclared)*
- `go run -tags evmcli ./cmd/echoevm -bin build/Add.bin -mode full -function 'add(uint256,uint256)' -args '1,2'` *(fails to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_68522480562083208e70777989fd4313