### PR TITLE
Add block range option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ behaviour:
 go run ./cmd/echoevm -bin path/to/contract.bin -mode [deploy|full] \
         [-calldata HEX | -function "sig" -args "1,2"]
 go run ./cmd/echoevm -block 1 [-rpc URL]
+go run ./cmd/echoevm -start-block 1 -end-block 50 [-rpc URL]
 ```
 
 *Note:* use the directory path (`./cmd/echoevm`) with `go run` so that all
@@ -30,6 +31,7 @@ flag parsing code located in `flags.go`.
   it contains. By default `-rpc` uses `https://cloudflare-eth.com`.
   The CLI prints the block number, how many contract transactions were found and
   how many executed successfully.
+- `-start-block`/`-end-block` – execute a range of blocks via RPC.
 
 ### Examples
 

--- a/cmd/echoevm/flags.go
+++ b/cmd/echoevm/flags.go
@@ -4,14 +4,16 @@ import "flag"
 
 // cliConfig holds command line parameters for echoevm.
 type cliConfig struct {
-	Bin      string
-	Mode     string
-	Function string
-	Args     string
-	Calldata string
-	LogLevel string
-	RPC      string
-	Block    int
+	Bin        string
+	Mode       string
+	Function   string
+	Args       string
+	Calldata   string
+	LogLevel   string
+	RPC        string
+	Block      int
+	StartBlock int
+	EndBlock   int
 }
 
 // parseFlags parses command line flags into a cliConfig.
@@ -25,8 +27,18 @@ func parseFlags() *cliConfig {
 	flag.StringVar(&cfg.LogLevel, "log-level", "info", "log level: trace, debug, info, warn, error")
 	flag.StringVar(&cfg.RPC, "rpc", "https://cloudflare-eth.com", "ethereum RPC endpoint")
 	flag.IntVar(&cfg.Block, "block", -1, "block number to execute contract transactions from")
+	flag.IntVar(&cfg.StartBlock, "start-block", -1, "start block number for range execution")
+	flag.IntVar(&cfg.EndBlock, "end-block", -1, "end block number for range execution")
 	flag.Parse()
-	if cfg.Block == -1 && cfg.Bin == "" {
+	if (cfg.StartBlock >= 0 || cfg.EndBlock >= 0) && !(cfg.StartBlock >= 0 && cfg.EndBlock >= 0) {
+		flag.Usage()
+		panic("both -start-block and -end-block must be provided")
+	}
+	if cfg.StartBlock >= 0 && cfg.EndBlock >= 0 && cfg.StartBlock > cfg.EndBlock {
+		flag.Usage()
+		panic("-start-block must be less than or equal to -end-block")
+	}
+	if cfg.Block == -1 && cfg.StartBlock == -1 && cfg.EndBlock == -1 && cfg.Bin == "" {
 		flag.Usage()
 		panic("-bin flag is required")
 	}


### PR DESCRIPTION
## Summary
- allow executing blocks from a start/end range via new CLI flags
- add `runBlockRange` helper
- document new flags in README

## Testing
- `go vet ./...` *(fails: access to storage.googleapis.com blocked)*
- `go test ./...` *(fails: access to storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a1afb5b1c8320b59f8c85df6c408c