### PR TITLE
Add basic opcode support

### DIFF
--- a/internal/evm/vm/interpreter.go
+++ b/internal/evm/vm/interpreter.go
@@ -2,6 +2,8 @@ package vm
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/rs/zerolog"
 	"github.com/smallyunet/echoevm/internal/evm/core"
 )
@@ -20,13 +22,15 @@ type Interpreter struct {
 	memory   *core.Memory
 	calldata []byte
 	returned []byte
+	storage  map[string]*big.Int
 }
 
 func New(code []byte) *Interpreter {
 	return &Interpreter{
-		code:   code,
-		stack:  core.NewStack(),
-		memory: core.NewMemory(),
+		code:    code,
+		stack:   core.NewStack(),
+		memory:  core.NewMemory(),
+		storage: make(map[string]*big.Int),
 	}
 }
 
@@ -53,10 +57,12 @@ func init() {
 	handlerMap[core.ADD] = opAdd
 	handlerMap[core.SUB] = opSub
 	handlerMap[core.MUL] = opMul
+	handlerMap[core.EXP] = opExp
 	handlerMap[core.DIV] = opDiv
 	handlerMap[core.MOD] = opMod
 	handlerMap[core.LT] = opLt
 	handlerMap[core.GT] = opGt
+	handlerMap[core.SGT] = opSgt
 	handlerMap[core.SLT] = opSlt
 	handlerMap[core.EQ] = opEq
 	handlerMap[core.ISZERO] = opIsZero
@@ -76,6 +82,7 @@ func init() {
 	handlerMap[core.MSTORE] = opMstore
 	handlerMap[core.MLOAD] = opMload
 	handlerMap[core.CODECOPY] = opCodecopy
+	handlerMap[core.SLOAD] = opSload
 
 	// stack
 	handlerMap[core.POP] = opPop
@@ -96,6 +103,7 @@ func init() {
 	handlerMap[core.CALLDATASIZE] = opCallDataSize
 	handlerMap[core.CALLDATALOAD] = opCallDataLoad
 	handlerMap[core.CALLDATACOPY] = opCallDataCopy
+	handlerMap[core.GAS] = opGas
 
 	// invalid opcode
 	handlerMap[core.INVALID] = opInvalid

--- a/internal/evm/vm/interpreter.go
+++ b/internal/evm/vm/interpreter.go
@@ -83,6 +83,7 @@ func init() {
 	handlerMap[core.MLOAD] = opMload
 	handlerMap[core.CODECOPY] = opCodecopy
 	handlerMap[core.SLOAD] = opSload
+	handlerMap[core.SSTORE] = opSstore
 
 	// stack
 	handlerMap[core.POP] = opPop
@@ -100,10 +101,13 @@ func init() {
 
 	// environment
 	handlerMap[core.CALLVALUE] = opCallValue
+	handlerMap[core.CALLER] = opCaller
 	handlerMap[core.CALLDATASIZE] = opCallDataSize
 	handlerMap[core.CALLDATALOAD] = opCallDataLoad
 	handlerMap[core.CALLDATACOPY] = opCallDataCopy
 	handlerMap[core.GAS] = opGas
+
+	handlerMap[core.DELEGATECALL] = opDelegateCall
 
 	// invalid opcode
 	handlerMap[core.INVALID] = opInvalid

--- a/internal/evm/vm/op_arithmetic.go
+++ b/internal/evm/vm/op_arithmetic.go
@@ -18,6 +18,14 @@ func opMul(i *Interpreter, _ byte) {
 	i.stack.Push(new(big.Int).Mul(x, y))
 }
 
+func opExp(i *Interpreter, _ byte) {
+	exp := i.stack.Pop()
+	base := i.stack.Pop()
+	r := new(big.Int).Exp(base, exp, nil)
+	r.And(r, mask256)
+	i.stack.Push(r)
+}
+
 func opDiv(i *Interpreter, _ byte) {
 	x, y := i.stack.Pop(), i.stack.Pop()
 	if y.Sign() == 0 {
@@ -70,6 +78,23 @@ func opLt(i *Interpreter, _ byte) {
 func opGt(i *Interpreter, _ byte) {
 	x, y := i.stack.Pop(), i.stack.Pop()
 	if x.Cmp(y) > 0 {
+		i.stack.Push(big.NewInt(1))
+	} else {
+		i.stack.Push(big.NewInt(0))
+	}
+}
+
+func opSgt(i *Interpreter, _ byte) {
+	x, y := i.stack.Pop(), i.stack.Pop()
+	sx := new(big.Int).Set(x)
+	if x.Bit(255) == 1 {
+		sx.Sub(sx, twoTo256)
+	}
+	sy := new(big.Int).Set(y)
+	if y.Bit(255) == 1 {
+		sy.Sub(sy, twoTo256)
+	}
+	if sx.Cmp(sy) > 0 {
 		i.stack.Push(big.NewInt(1))
 	} else {
 		i.stack.Push(big.NewInt(0))

--- a/internal/evm/vm/op_arithmetic_test.go
+++ b/internal/evm/vm/op_arithmetic_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func newInterp() *Interpreter {
-	return &Interpreter{stack: core.NewStack(), memory: core.NewMemory()}
+	return &Interpreter{stack: core.NewStack(), memory: core.NewMemory(), storage: make(map[string]*big.Int)}
 }
 
 func TestOpAdd(t *testing.T) {
@@ -37,5 +37,26 @@ func TestOpEq(t *testing.T) {
 	opEq(i, 0)
 	if i.stack.Pop().Int64() != 1 {
 		t.Fatalf("eq failed")
+	}
+}
+
+func TestOpExp(t *testing.T) {
+	i := newInterp()
+	i.stack.Push(big.NewInt(2)) // base
+	i.stack.Push(big.NewInt(3)) // exponent
+	opExp(i, 0)
+	if i.stack.Pop().Int64() != 8 {
+		t.Fatalf("exp failed")
+	}
+}
+
+func TestOpSgt(t *testing.T) {
+	i := newInterp()
+	negOne := new(big.Int).Sub(twoTo256, big.NewInt(1))
+	i.stack.Push(negOne)        // y = -1
+	i.stack.Push(big.NewInt(1)) // x = 1
+	opSgt(i, 0)
+	if i.stack.Pop().Int64() != 1 {
+		t.Fatalf("sgt failed")
 	}
 }

--- a/internal/evm/vm/op_call.go
+++ b/internal/evm/vm/op_call.go
@@ -1,0 +1,14 @@
+package vm
+
+import "math/big"
+
+// opDelegateCall is a stub that always fails. It pops the expected
+// arguments and pushes 0 to indicate failure.
+func opDelegateCall(i *Interpreter, _ byte) {
+	for n := 0; n < 6; n++ {
+		if i.stack.Len() > 0 {
+			i.stack.Pop()
+		}
+	}
+	i.stack.Push(big.NewInt(0))
+}

--- a/internal/evm/vm/op_call_test.go
+++ b/internal/evm/vm/op_call_test.go
@@ -1,0 +1,18 @@
+package vm
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestOpDelegateCall(t *testing.T) {
+	i := newInterp()
+	// push dummy arguments
+	for j := 0; j < 6; j++ {
+		i.stack.Push(big.NewInt(int64(j)))
+	}
+	opDelegateCall(i, 0)
+	if i.stack.Pop().Sign() != 0 {
+		t.Fatalf("delegatecall should push 0")
+	}
+}

--- a/internal/evm/vm/op_env.go
+++ b/internal/evm/vm/op_env.go
@@ -7,6 +7,12 @@ func opCallValue(i *Interpreter, _ byte) {
 	i.stack.Push(big.NewInt(0)) // default to 0
 }
 
+// opCaller pushes the address of the caller. Since this interpreter does not
+// model accounts, the value is always zero.
+func opCaller(i *Interpreter, _ byte) {
+	i.stack.Push(big.NewInt(0))
+}
+
 // opCallDataSize pushes the size of the calldata onto the stack. If no calldata
 // is provided it returns 0.
 func opCallDataSize(i *Interpreter, _ byte) {

--- a/internal/evm/vm/op_env.go
+++ b/internal/evm/vm/op_env.go
@@ -39,6 +39,10 @@ func opCallDataCopy(i *Interpreter, _ byte) {
 	i.memory.Write(memOffset, segment)
 }
 
+func opGas(i *Interpreter, _ byte) {
+	i.stack.Push(big.NewInt(0))
+}
+
 func min(a, b uint64) uint64 {
 	if a < b {
 		return a

--- a/internal/evm/vm/op_env_test.go
+++ b/internal/evm/vm/op_env_test.go
@@ -31,3 +31,11 @@ func TestGas(t *testing.T) {
 		t.Fatalf("gas should push 0")
 	}
 }
+
+func TestCaller(t *testing.T) {
+	i := newInterp()
+	opCaller(i, 0)
+	if i.stack.Pop().Sign() != 0 {
+		t.Fatalf("caller should push 0")
+	}
+}

--- a/internal/evm/vm/op_env_test.go
+++ b/internal/evm/vm/op_env_test.go
@@ -23,3 +23,11 @@ func TestCallDataLoad(t *testing.T) {
 		t.Fatalf("calldataload wrong")
 	}
 }
+
+func TestGas(t *testing.T) {
+	i := newInterp()
+	opGas(i, 0)
+	if i.stack.Pop().Sign() != 0 {
+		t.Fatalf("gas should push 0")
+	}
+}

--- a/internal/evm/vm/op_storage.go
+++ b/internal/evm/vm/op_storage.go
@@ -15,6 +15,13 @@ func opSload(i *Interpreter, _ byte) {
 	}
 }
 
+func opSstore(i *Interpreter, _ byte) {
+	val := i.stack.Pop()
+	key := i.stack.Pop()
+	k := storageKey(key)
+	i.storage[k] = new(big.Int).Set(val)
+}
+
 func storageKey(k *big.Int) string {
 	b := make([]byte, 32)
 	k.FillBytes(b)

--- a/internal/evm/vm/op_storage.go
+++ b/internal/evm/vm/op_storage.go
@@ -1,0 +1,22 @@
+package vm
+
+import (
+	"encoding/hex"
+	"math/big"
+)
+
+func opSload(i *Interpreter, _ byte) {
+	key := i.stack.Pop()
+	k := storageKey(key)
+	if val, ok := i.storage[k]; ok {
+		i.stack.Push(new(big.Int).Set(val))
+	} else {
+		i.stack.Push(big.NewInt(0))
+	}
+}
+
+func storageKey(k *big.Int) string {
+	b := make([]byte, 32)
+	k.FillBytes(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/evm/vm/op_storage_test.go
+++ b/internal/evm/vm/op_storage_test.go
@@ -15,3 +15,14 @@ func TestOpSload(t *testing.T) {
 		t.Fatalf("sload failed")
 	}
 }
+
+func TestOpSstore(t *testing.T) {
+	i := newInterp()
+	key := big.NewInt(1)
+	i.stack.Push(key)
+	i.stack.Push(big.NewInt(7))
+	opSstore(i, 0)
+	if i.storage[storageKey(key)].Int64() != 7 {
+		t.Fatalf("sstore failed")
+	}
+}

--- a/internal/evm/vm/op_storage_test.go
+++ b/internal/evm/vm/op_storage_test.go
@@ -1,0 +1,17 @@
+package vm
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestOpSload(t *testing.T) {
+	i := newInterp()
+	key := big.NewInt(1)
+	i.storage[storageKey(key)] = big.NewInt(42)
+	i.stack.Push(key)
+	opSload(i, 0)
+	if i.stack.Pop().Int64() != 42 {
+		t.Fatalf("sload failed")
+	}
+}


### PR DESCRIPTION
## Summary
- implement EXP and SGT arithmetic operations
- support SLOAD via simple interpreter storage
- return 0 for GAS opcode
- register new opcode handlers
- add tests for new functionality

## Testing
- `go test ./...` *(fails: Forbidden download)*
- `go vet ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_68667466d65c8320b4fd842c3c1eae2d