### PR TITLE
Implement BLOCKNUMBER opcode

### DIFF
--- a/cmd/echoevm/main.go
+++ b/cmd/echoevm/main.go
@@ -228,6 +228,7 @@ func runBlock(ctx context.Context, client *ethclient.Client, blockNum int) {
 		if tx.To() == nil {
 			logger.Info().Msgf("tx %d: contract creation", idx)
 			interpreter := vm.New(data)
+			interpreter.SetBlockNumber(block.NumberU64())
 			if err := run(interpreter); err != nil {
 				logger.Error().Msgf("tx %d failed: %v", idx, err)
 				continue
@@ -244,6 +245,7 @@ func runBlock(ctx context.Context, client *ethclient.Client, blockNum int) {
 		}
 		logger.Info().Msgf("tx %d: call %s", idx, tx.To().Hex())
 		interpreter := vm.NewWithCallData(code, data)
+		interpreter.SetBlockNumber(block.NumberU64())
 		if err := run(interpreter); err != nil {
 			logger.Error().Msgf("tx %d failed: %v", idx, err)
 			continue

--- a/internal/evm/vm/interpreter.go
+++ b/internal/evm/vm/interpreter.go
@@ -16,13 +16,14 @@ func SetLogger(l zerolog.Logger) {
 }
 
 type Interpreter struct {
-	code     []byte
-	pc       uint64
-	stack    *core.Stack
-	memory   *core.Memory
-	calldata []byte
-	returned []byte
-	storage  map[string]*big.Int
+	code        []byte
+	pc          uint64
+	stack       *core.Stack
+	memory      *core.Memory
+	calldata    []byte
+	returned    []byte
+	storage     map[string]*big.Int
+	blockNumber uint64
 }
 
 func New(code []byte) *Interpreter {
@@ -44,6 +45,11 @@ func NewWithCallData(code []byte, data []byte) *Interpreter {
 // SetCallData sets the calldata that opcodes like CALLDATALOAD operate on.
 func (i *Interpreter) SetCallData(data []byte) {
 	i.calldata = data
+}
+
+// SetBlockNumber sets the block number used by environment opcodes like NUMBER.
+func (i *Interpreter) SetBlockNumber(num uint64) {
+	i.blockNumber = num
 }
 
 // OpcodeHandler defines a function that executes a specific opcode
@@ -106,6 +112,7 @@ func init() {
 	handlerMap[core.CALLDATALOAD] = opCallDataLoad
 	handlerMap[core.CALLDATACOPY] = opCallDataCopy
 	handlerMap[core.GAS] = opGas
+	handlerMap[core.NUMBER] = opNumber
 
 	handlerMap[core.DELEGATECALL] = opDelegateCall
 

--- a/internal/evm/vm/op_env.go
+++ b/internal/evm/vm/op_env.go
@@ -49,6 +49,10 @@ func opGas(i *Interpreter, _ byte) {
 	i.stack.Push(big.NewInt(0))
 }
 
+func opNumber(i *Interpreter, _ byte) {
+	i.stack.Push(big.NewInt(int64(i.blockNumber)))
+}
+
 func min(a, b uint64) uint64 {
 	if a < b {
 		return a

--- a/internal/evm/vm/op_env_test.go
+++ b/internal/evm/vm/op_env_test.go
@@ -39,3 +39,12 @@ func TestCaller(t *testing.T) {
 		t.Fatalf("caller should push 0")
 	}
 }
+
+func TestNumber(t *testing.T) {
+	i := newInterp()
+	i.SetBlockNumber(123)
+	opNumber(i, 0)
+	if i.stack.Pop().Int64() != 123 {
+		t.Fatalf("number wrong")
+	}
+}


### PR DESCRIPTION
## Summary
- support the EVM NUMBER opcode
- expose block number on the interpreter
- set block number when executing transactions
- test NUMBER opcode

## Testing
- `go test ./...` *(fails: Get "https://storage.googleapis.com/...": Forbidden)*
- `go vet ./...` *(fails: Get "https://storage.googleapis.com/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68676bc5fd948320a9d50dc5f02915f2