### PR TITLE
Introduce subcommands for echoevm CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,47 +4,48 @@ echoevm is a minimal Ethereum Virtual Machine (EVM) implementation in Go, focusi
 
 ## Usage
 
-The `echoevm` command can execute the constructor contained in a Solidity
-`.bin` file. By default it runs the deployment bytecode and, if runtime code is
-returned, executes that code as well. Use the following flags to customise the
-behaviour:
+The `echoevm` command is organised into subcommands to keep flags manageable.
+The `run` subcommand executes the constructor contained in a Solidity `.bin`
+file and, if runtime code is returned, runs that too. Use the following flags to
+customise the behaviour:
 
 ```
-go run ./cmd/echoevm -bin path/to/contract.bin -mode [deploy|full] \
+go run ./cmd/echoevm run -bin path/to/contract.bin -mode [deploy|full] \
         [-calldata HEX | -function "sig" -args "1,2"]
-go run ./cmd/echoevm -block 1 [-rpc URL]
-go run ./cmd/echoevm -start-block 1 -end-block 50 [-rpc URL]
+go run ./cmd/echoevm block -block 1 [-rpc URL]
+go run ./cmd/echoevm range -start 1 -end 50 [-rpc URL]
 ```
 
 *Note:* use the directory path (`./cmd/echoevm`) with `go run` so that all
 source files are compiled. Running `go run ./cmd/echoevm/main.go` will omit the
 flag parsing code located in `flags.go`.
 
-- `-bin`  – path to the hex encoded bytecode file (**required**).
-- `-mode` – `deploy` to only run the constructor or `full` to also execute the
-  returned runtime code (default `full`).
-- `-calldata` – hex-encoded calldata to supply when running the runtime code.
-- `-function`/`-args` – alternatively specify a function signature and comma
-  separated arguments (e.g. `-function "add(uint256,uint256)" -args "1,2"`)
-  which will be ABI encoded automatically. One of `-calldata` or `-function`/`-args` is required when running in `full` mode.
-- `-block`/`-rpc` – fetch a block via RPC and execute all contract transactions
-  it contains. By default `-rpc` uses `https://cloudflare-eth.com`.
-  The CLI prints the block number, how many contract transactions were found and
-  how many executed successfully.
-- `-start-block`/`-end-block` – execute a range of blocks via RPC.
+- `run` subcommand:
+  - `-bin`  – path to the hex encoded bytecode file (**required**).
+  - `-mode` – `deploy` to only run the constructor or `full` to also execute the
+    returned runtime code (default `full`).
+  - `-calldata` – hex-encoded calldata for the runtime code.
+  - `-function`/`-args` – alternatively specify a function signature and comma
+    separated arguments (e.g. `-function "add(uint256,uint256)" -args "1,2"`)
+    which will be ABI encoded automatically.
+- `block` subcommand:
+  - `-block`/`-rpc` – fetch a single block via RPC. By default `-rpc` uses
+    `https://cloudflare-eth.com`.
+- `range` subcommand:
+  - `-start`/`-end`/`-rpc` – execute a range of blocks via RPC.
 
 ### Examples
 
 Run with pre-encoded calldata:
 
 ```bash
-go run ./cmd/echoevm -mode full -calldata 771602f7...
+go run ./cmd/echoevm run -mode full -calldata 771602f7...
 ```
 
 Encode arguments automatically for a function call:
 
 ```bash
-go run ./cmd/echoevm -mode full -function 'add(uint256,uint256)' -args "1,2"
+go run ./cmd/echoevm run -mode full -function 'add(uint256,uint256)' -args "1,2"
 ```
 
 ## Testing

--- a/cmd/echoevm/flags_test.go
+++ b/cmd/echoevm/flags_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestParseFlags(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	os.Args = []string{"cmd", "-bin", "x.bin"}
-	cfg := parseFlags()
+	os.Args = []string{"cmd", "run", "-bin", "x.bin"}
+	_, cfg := parseFlags()
 	if cfg.Bin != "x.bin" {
 		t.Fatalf("unexpected bin %s", cfg.Bin)
 	}

--- a/cmd/echoevm/main.go
+++ b/cmd/echoevm/main.go
@@ -21,7 +21,7 @@ import (
 var logger zerolog.Logger
 
 func main() {
-	cfg := parseFlags()
+	cmd, cfg := parseFlags()
 	lvl, err := zerolog.ParseLevel(strings.ToLower(cfg.LogLevel))
 	if err != nil {
 		lvl = zerolog.InfoLevel
@@ -31,12 +31,11 @@ func main() {
 	logger = zerolog.New(cw).With().Timestamp().Logger()
 	vm.SetLogger(logger)
 
-	if cfg.StartBlock >= 0 && cfg.EndBlock >= 0 {
+	switch cmd {
+	case "range":
 		runBlockRange(cfg)
 		return
-	}
-
-	if cfg.Block >= 0 {
+	case "block":
 		ctx := context.Background()
 		client, err := ethclient.DialContext(ctx, cfg.RPC)
 		check(err, "failed to connect to RPC endpoint")


### PR DESCRIPTION
## Summary
- support `run`, `block` and `range` subcommands in CLI
- update flag parsing and related tests
- document new subcommand usage

## Testing
- `go test ./...` *(fails: forbidden storage.googleapis.com)*
- `go vet ./...` *(fails: forbidden storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6868f51ad9a883209eb57375970fcdd0